### PR TITLE
fix: Move firebase token to the request header for sign up and restructure authentication response

### DIFF
--- a/api/dto/authentication_response.go
+++ b/api/dto/authentication_response.go
@@ -1,10 +1,7 @@
 package dto
 
 type AuthenticationResponse struct {
-	ID           uint   `json:"id"`
-	Role         string `json:"role"`
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-	FirstName    string `json:"first_name"`
-	LastName     string `json:"last_name"`
+	AccessToken  string  `json:"access_token"`
+	RefreshToken string  `json:"refresh_token"`
+	User         *UserDto `json:"user"`
 }

--- a/api/dto/signup_request.go
+++ b/api/dto/signup_request.go
@@ -8,12 +8,11 @@ import (
 )
 
 type SignUpRequest struct {
-	FirstName                    string `json:"first_name"`
-	LastName                     string `json:"last_name"`
-	Password                     string `json:"password"`
-	PhoneNumber                  string `json:"phone_number"`
-	Role                         string `json:"role"`
-	PhoneNumberVerificationToken string `json:"phone_number_verification_token"`
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	Password    string `json:"password"`
+	PhoneNumber string `json:"phone_number"`
+	Role        string `json:"role"`
 }
 
 func (request SignUpRequest) Validate() error {
@@ -44,10 +43,6 @@ func (request SignUpRequest) Validate() error {
 					entity.RoleUser, entity.RoleAttendant,
 				),
 			),
-		),
-		validation.Field(
-			&request.PhoneNumberVerificationToken,
-			validation.Required.Error("Phone number verificaiton token is required"),
 		),
 	)
 }

--- a/api/dto/user.go
+++ b/api/dto/user.go
@@ -1,6 +1,7 @@
 package dto
 
 type UserDto struct {
+	ID          uint   `json:"id"`
 	PhoneNumber string `json:"phone_number" gorm:"unique"`
 	FirstName   string `json:"first_name"`
 	LastName    string `json:"last_name"`

--- a/api/handler/user_handler.go
+++ b/api/handler/user_handler.go
@@ -4,6 +4,7 @@ import (
 	"lot/api/dto"
 	app_errors "lot/internal/errors"
 	"lot/internal/service"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -30,8 +31,9 @@ func SignUpHandler(userService service.UserService, authService service.AuthServ
 				},
 			)
 		}
+		token := strings.Split(c.Get("Authorization"), " ")[1]
 
-		isTokenValid, err := authService.VerifyPhoneNumberAuthenticationToken(request.PhoneNumberVerificationToken)
+		isTokenValid, err := authService.VerifyPhoneNumberAuthenticationToken(token)
 
 		if err != nil || !isTokenValid {
 			return c.Status(fiber.StatusBadRequest).JSON(
@@ -53,6 +55,10 @@ func SignUpHandler(userService service.UserService, authService service.AuthServ
 				},
 			)
 		}
-		return c.JSON(user)
+		return c.JSON(
+			dto.ApiResponse{
+				Data: user, Status: 200, Message: "Success",
+			},
+		)
 	}
 }

--- a/internal/repository/mocks/mock_user_repository.go
+++ b/internal/repository/mocks/mock_user_repository.go
@@ -10,9 +10,9 @@ type MockUserRepository struct {
 	mock.Mock
 }
 
-func (m *MockUserRepository) Save(user entity.User) error {
+func (m *MockUserRepository) Save(user entity.User) (*entity.User, error) {
 	args := m.Called(user)
-	return args.Error(0)
+	return args.Get(0).(*entity.User), args.Error(1)
 }
 
 func (m *MockUserRepository) Delete(user entity.User) error {

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -11,7 +11,7 @@ type userRepository struct {
 }
 
 type UserRepository interface {
-	Save(user entity.User) error
+	Save(user entity.User) (*entity.User, error)
 	Delete(user entity.User) error
 	FindById(id uint) (*entity.User, error)
 	FindByPhoneNumber(phoneNumber string) (*entity.User, error)
@@ -33,12 +33,12 @@ func (u userRepository) FindById(id uint) (*entity.User, error) {
 	return &user, nil
 }
 
-func (u userRepository) Save(user entity.User) error {
-	result := u.DB.Save(&user)
+func (u userRepository) Save(user entity.User) (*entity.User, error) {
+	result := u.DB.Create(&user)
 	if result.Error != nil {
-		return result.Error
+		return nil, result.Error
 	}
-	return nil
+	return &user, nil
 }
 
 func (u userRepository) Delete(user entity.User) error {

--- a/internal/repository/user_repository_test.go
+++ b/internal/repository/user_repository_test.go
@@ -35,7 +35,7 @@ func TestSave(t *testing.T) {
 	t.Run("Should return nil after saving successfully", func(t *testing.T) {
 		db := setupTestDatabase_UserRepository()
 		userRepository := NewUserRepository(db)
-		err := userRepository.Save(user1)
+		_, err := userRepository.Save(user1)
 
 		assert.Nil(t, err)
 	})
@@ -46,7 +46,7 @@ func TestSave(t *testing.T) {
 		sqlDb, _ := db.DB()
 		_ = sqlDb.Close()
 
-		err := userRepository.Save(user1)
+		_, err := userRepository.Save(user1)
 
 		assert.Error(t, err)
 	})
@@ -67,7 +67,7 @@ func TestFindById(t *testing.T) {
 	t.Run("Should return previously saved user", func(t *testing.T) {
 		db := setupTestDatabase_UserRepository()
 		userRepository := NewUserRepository(db)
-		_ = userRepository.Save(user1)
+		_, _ = userRepository.Save(user1)
 
 		user, err := userRepository.FindById(1)
 
@@ -105,7 +105,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Should return nil after deleting successfully", func(t *testing.T) {
 		db := setupTestDatabase_UserRepository()
 		userRepository := NewUserRepository(db)
-		_ = userRepository.Save(user1)
+		_, _ = userRepository.Save(user1)
 		savedUser, _ := userRepository.FindById(1)
 
 		err := userRepository.Delete(*savedUser)
@@ -116,7 +116,7 @@ func TestDelete(t *testing.T) {
 	t.Run("Should an error when an error occurs", func(t *testing.T) {
 		db := setupTestDatabase_UserRepository()
 		userRepository := NewUserRepository(db)
-		_ = userRepository.Save(user1)
+		_, _ = userRepository.Save(user1)
 		savedUser, _ := userRepository.FindById(1)
 		sqlDb, _ := db.DB()
 		_ = sqlDb.Close()
@@ -142,7 +142,7 @@ func TestFindByPhoneNumber(t *testing.T) {
 	t.Run("Should return previously saved user", func(t *testing.T) {
 		db := setupTestDatabase_UserRepository()
 		userRepository := NewUserRepository(db)
-		_ = userRepository.Save(user1)
+		_, _ = userRepository.Save(user1)
 
 		user, err := userRepository.FindByPhoneNumber(user1.PhoneNumber)
 

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -65,12 +65,9 @@ func (a authService) SignIn(request dto.LoginRequest) (*dto.AuthenticationRespon
 	}
 
 	response := dto.AuthenticationResponse{
-		ID:           user.ID,
-		Role:         user.Role.Name,
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		FirstName:    user.FirstName,
-		LastName:     user.LastName,
+		User: toDto(*user),
 	}
 
 	return &response, nil
@@ -134,12 +131,9 @@ func (a authService) RefreshToken(request dto.TokenRefreshRequest) (*dto.Authent
 	}
 
 	response := dto.AuthenticationResponse{
-		ID:           user.ID,
-		Role:         user.Role.Name,
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
-		FirstName:    user.FirstName,
-		LastName:     user.LastName,
+		User:         toDto(*user),
 	}
 	return &response, nil
 }

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -36,7 +36,7 @@ func (u userService) SignUp(request dto.SignUpRequest) (*dto.UserDto, error) {
 		return nil, errors.New("role not found")
 	}
 
-	if _, err := u.userRepository.FindByPhoneNumber(request.PhoneNumber); err == app_errors.ErrRecordNotFound {
+	if _, err := u.userRepository.FindByPhoneNumber(request.PhoneNumber); err != app_errors.ErrRecordNotFound {
 		return nil, errors.New("an account with that phone number already exists")
 	}
 
@@ -54,11 +54,12 @@ func (u userService) SignUp(request dto.SignUpRequest) (*dto.UserDto, error) {
 		RoleID:      role.ID,
 	}
 
-	if err := u.userRepository.Save(user); err != nil {
+	savedUser, err := u.userRepository.Save(user)
+	if err != nil {
 		return nil, err
 	}
 
-	return toDto(user), nil
+	return toDto(*savedUser), nil
 }
 
 func (u userService) hashPassword(password string) (string, error) {
@@ -72,5 +73,6 @@ func toDto(user entity.User) *dto.UserDto {
 		LastName:    user.LastName,
 		PhoneNumber: user.PhoneNumber,
 		Role:        user.Role.Name,
+		ID:          user.ID,
 	}
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

<!-- Delete the statuses that don't apply -->

**READY**

## Breaking Changes
<!-- Delete the statuses that don't apply -->
YES

## Description
<!--- Describe your changes in detail -->
This PR 
- Moves the firebase token from the sign up request body to the request header
- Restructures the authentication response to have a user object instead of sending all user details and tokens in one object
- Fixes a bug when checking if a phone number is previously taken or not


## Related Issues

<!-- Attach list of issues related to this PR here -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
